### PR TITLE
fix:market-client api namespace inconsistent

### DIFF
--- a/cli/util.go
+++ b/cli/util.go
@@ -42,6 +42,11 @@ var CidBaseFlag = cli.StringFlag{
 	DefaultText: "base32",
 }
 
+const (
+	API_NAMESPACE_VENUS_MARKET  = "VENUS_MARKET"
+	API_NAMESPACE_MARKET_CLIENT = "VENUS_MARKET_CLIENT"
+)
+
 // GetCidEncoder returns an encoder using the `cid-base` flag if provided, or
 // the default (Base32) encoder if not.
 func GetCidEncoder(cctx *cli.Context) (cidenc.Encoder, error) {
@@ -91,7 +96,7 @@ func NewMarketNode(cctx *cli.Context) (api.MarketFullNode, jsonrpc.ClientCloser,
 	}
 
 	impl := &api.MarketFullNodeStruct{}
-	closer, err := jsonrpc.NewMergeClient(cctx.Context, addr, "VENUS_MARKET", []interface{}{impl}, apiInfo.AuthHeader())
+	closer, err := jsonrpc.NewMergeClient(cctx.Context, addr, API_NAMESPACE_VENUS_MARKET, []interface{}{impl}, apiInfo.AuthHeader())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -119,7 +124,7 @@ func NewMarketClientNode(cctx *cli.Context) (api.MarketClientNode, jsonrpc.Clien
 	}
 
 	impl := &api.MarketClientNodeStruct{}
-	closer, err := jsonrpc.NewMergeClient(cctx.Context, addr, "VENUS_MARKET", []interface{}{impl}, apiInfo.AuthHeader())
+	closer, err := jsonrpc.NewMergeClient(cctx.Context, addr, API_NAMESPACE_MARKET_CLIENT, []interface{}{impl}, apiInfo.AuthHeader())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/market-client/main.go
+++ b/cmd/market-client/main.go
@@ -231,5 +231,5 @@ func marketClient(cctx *cli.Context) error {
 		return xerrors.Errorf("initializing node: %w", err)
 	}
 	finishCh := utils.MonitorShutdown(shutdownChan)
-	return rpc.ServeRPC(ctx, cfg, &cfg.API, mux.NewRouter(), 1000, "VENUS_MARKET_CLIENT", "", (api.MarketClientNode)(resAPI), finishCh)
+	return rpc.ServeRPC(ctx, cfg, &cfg.API, mux.NewRouter(), 1000, cli2.API_NAMESPACE_MARKET_CLIENT, "", (api.MarketClientNode)(resAPI), finishCh)
 }

--- a/cmd/venus-market/main.go
+++ b/cmd/venus-market/main.go
@@ -248,7 +248,7 @@ func daemon(cctx *cli.Context) error {
 
 	mux := mux2.NewRouter()
 	mux.Handle("resource", rpc.NewPieceStorageServer(resAPI.PieceStorage))
-	return rpc.ServeRPC(ctx, cfg, &cfg.API, mux, 1000, "VENUS_MARKET", "", api.MarketFullNode(resAPI), finishCh)
+	return rpc.ServeRPC(ctx, cfg, &cfg.API, mux, 1000, cli2.API_NAMESPACE_VENUS_MARKET, "", api.MarketFullNode(resAPI), finishCh)
 }
 
 func flagData(cctx *cli.Context, cfg *config.MarketConfig) error {


### PR DESCRIPTION
fix:market-client api namespace on the server side inconsistent with client side.

this causes following error:

```shell
2021-12-08T17:07:18.185+0800	ERROR	rpc	go-jsonrpc@v0.1.4-0.20210721095535-a67dff16de21/server.go:103	RPC Error: method 'VENUS_MARKET.ClientListImports' not found
```