### PR TITLE
Feat/dtynn/support more spec policy in assign unpacked deals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/filecoin-project/specs-actors/v2 v2.3.6
 	github.com/filecoin-project/specs-actors/v7 v7.0.0
 	github.com/filecoin-project/specs-storage v0.2.2
-	github.com/filecoin-project/venus v1.2.4-0.20220513080706-da04e9bf814b
+	github.com/filecoin-project/venus v1.2.4-0.20220513124310-19620ae8f081
 	github.com/filecoin-project/venus-auth v1.4.1-0.20220511080155-bc171c3a3ec5
 	github.com/filecoin-project/venus-messager v1.2.2-rc1.0.20220420091920-4820c01ca309
 	github.com/gbrlsnchs/jwt/v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/filecoin-project/specs-actors/v2 v2.3.6
 	github.com/filecoin-project/specs-actors/v7 v7.0.0
 	github.com/filecoin-project/specs-storage v0.2.2
-	github.com/filecoin-project/venus v1.2.4-0.20220420072943-4d565663fa60
+	github.com/filecoin-project/venus v1.2.4-0.20220513080706-da04e9bf814b
 	github.com/filecoin-project/venus-auth v1.4.1-0.20220511080155-bc171c3a3ec5
 	github.com/filecoin-project/venus-messager v1.2.2-rc1.0.20220420091920-4820c01ca309
 	github.com/gbrlsnchs/jwt/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -406,8 +406,8 @@ github.com/filecoin-project/storetheindex v0.3.5 h1:KoS9TvjPm6zIZfUH8atAHJbVHOO7
 github.com/filecoin-project/storetheindex v0.3.5/go.mod h1:0r3d0kSpK63O6AvLr1CjAINLi+nWD49clzcnKV+GLpI=
 github.com/filecoin-project/test-vectors/schema v0.0.5/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
 github.com/filecoin-project/venus v1.2.4-0.20220420072943-4d565663fa60/go.mod h1:hJULXHGAnWuq5S5KRtPkwbT8DqgM9II7NwyNU7t59D0=
-github.com/filecoin-project/venus v1.2.4-0.20220513080706-da04e9bf814b h1:h1ynYyT/LX+pTvfdWKupq07y8DkVaQV9tXsPM55zzas=
-github.com/filecoin-project/venus v1.2.4-0.20220513080706-da04e9bf814b/go.mod h1:hJULXHGAnWuq5S5KRtPkwbT8DqgM9II7NwyNU7t59D0=
+github.com/filecoin-project/venus v1.2.4-0.20220513124310-19620ae8f081 h1:5xYmE4Hv6He+98gz/IablDEJWtSpVZmT6bLhhpKxCNs=
+github.com/filecoin-project/venus v1.2.4-0.20220513124310-19620ae8f081/go.mod h1:hJULXHGAnWuq5S5KRtPkwbT8DqgM9II7NwyNU7t59D0=
 github.com/filecoin-project/venus-auth v1.3.2/go.mod h1:m5Jog2GYxztwP7w3m/iJdv/V1/bTcAVU9rm/CbhxRQU=
 github.com/filecoin-project/venus-auth v1.3.3-0.20220406063133-896f44f6e816/go.mod h1:SSoeDlHPdYRHEqLdwvCykInHQLaKyXbRKR8P70R5j8w=
 github.com/filecoin-project/venus-auth v1.4.1-0.20220511080155-bc171c3a3ec5 h1:DJ97rvYLE00epc/vwjPSj2Jt7giBi+F4RUVMsBmdHpY=

--- a/go.sum
+++ b/go.sum
@@ -405,10 +405,10 @@ github.com/filecoin-project/specs-storage v0.2.2/go.mod h1:6cc/lncmAxMUocPi0z1EP
 github.com/filecoin-project/storetheindex v0.3.5 h1:KoS9TvjPm6zIZfUH8atAHJbVHOO7GTP1MdTG+v0eE+Q=
 github.com/filecoin-project/storetheindex v0.3.5/go.mod h1:0r3d0kSpK63O6AvLr1CjAINLi+nWD49clzcnKV+GLpI=
 github.com/filecoin-project/test-vectors/schema v0.0.5/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
-github.com/filecoin-project/venus v1.2.4-0.20220420072943-4d565663fa60 h1:0Wg4LHlx9a1NnfCfaWDU+vDv4LvWXp/21zzENqjXZwM=
 github.com/filecoin-project/venus v1.2.4-0.20220420072943-4d565663fa60/go.mod h1:hJULXHGAnWuq5S5KRtPkwbT8DqgM9II7NwyNU7t59D0=
+github.com/filecoin-project/venus v1.2.4-0.20220513080706-da04e9bf814b h1:h1ynYyT/LX+pTvfdWKupq07y8DkVaQV9tXsPM55zzas=
+github.com/filecoin-project/venus v1.2.4-0.20220513080706-da04e9bf814b/go.mod h1:hJULXHGAnWuq5S5KRtPkwbT8DqgM9II7NwyNU7t59D0=
 github.com/filecoin-project/venus-auth v1.3.2/go.mod h1:m5Jog2GYxztwP7w3m/iJdv/V1/bTcAVU9rm/CbhxRQU=
-github.com/filecoin-project/venus-auth v1.3.3-0.20220406063133-896f44f6e816 h1:SKHcLVX4A0QGY0G+vHbv7KalZ3xgiXSxf4i26Zh+c3Q=
 github.com/filecoin-project/venus-auth v1.3.3-0.20220406063133-896f44f6e816/go.mod h1:SSoeDlHPdYRHEqLdwvCykInHQLaKyXbRKR8P70R5j8w=
 github.com/filecoin-project/venus-auth v1.4.1-0.20220511080155-bc171c3a3ec5 h1:DJ97rvYLE00epc/vwjPSj2Jt7giBi+F4RUVMsBmdHpY=
 github.com/filecoin-project/venus-auth v1.4.1-0.20220511080155-bc171c3a3ec5/go.mod h1:x/Cv3zz9z5O+/uqIKgYtk5UsL7nYu+CtiPjyVQ8Lywg=

--- a/storageprovider/deal_assign_util.go
+++ b/storageprovider/deal_assign_util.go
@@ -19,37 +19,63 @@ var (
 )
 
 func pickAndAlign(deals []*mtypes.DealInfoIncludePath, ssize abi.SectorSize, spec *mtypes.GetDealSpec) ([]*mtypes.DealInfoIncludePath, error) {
-	dealCount := len(deals)
-	if dealCount == 0 {
-		return nil, nil
-	}
-
 	space := abi.PaddedPieceSize(ssize)
 
 	if err := space.Validate(); err != nil {
 		return nil, fmt.Errorf("%w: %d", errInvalidSpaceSize, space)
 	}
 
-	if psize := deals[0].PieceSize; psize.Validate() != nil {
-		return nil, fmt.Errorf("%w: first deal size: %d", errInvalidDealPieceSize, psize)
+	if len(deals) > 0 && deals[0].PieceSize.Validate() != nil {
+		return nil, fmt.Errorf("%w: first deal size: %d", errInvalidDealPieceSize, deals[0].PieceSize)
 	}
 
-	var dealLimit *int
-	var dealSizeLimit *abi.PaddedPieceSize
-	if spec != nil {
-		if spec.MaxPiece > 0 {
-			dealLimit = &spec.MaxPiece
+	// 过滤掉太小的 deals
+	if spec != nil && spec.MinPieceSize > 0 {
+		limit := abi.PaddedPieceSize(spec.MinPieceSize)
+		first := len(deals)
+
+		// find the first deal index with piece size >= limit,
+		// or all deals are too small
+		for i := 0; i < len(deals); i++ {
+			if deals[i].PieceSize >= limit {
+				first = i
+				break
+			}
 		}
 
-		if spec.MaxPieceSize > 0 {
-			limit := abi.PaddedPieceSize(spec.MaxPieceSize)
-			dealSizeLimit = &limit
+		deals = deals[first:]
+	}
+
+	// 过滤掉太大的 deals
+	if spec != nil && spec.MaxPieceSize > 0 {
+		limit := abi.PaddedPieceSize(spec.MaxPieceSize)
+
+		last := 0
+
+		// find the last deal index with piece size <= limit,
+		// or all deals are too large
+		for i := len(deals); i > 0; i-- {
+			if deals[i-1].PieceSize <= limit {
+				last = i
+				break
+			}
 		}
+
+		deals = deals[:last]
+	}
+
+	// only the deals left
+	dealCount := len(deals)
+	if dealCount == 0 {
+		return nil, nil
 	}
 
 	res := make([]*mtypes.DealInfoIncludePath, 0)
 	di := 0
 	checked := 0
+
+	pickedDeals := 0
+	pickedSpace := abi.PaddedPieceSize(0)
 
 	var offset abi.UnpaddedPieceSize
 	for di < dealCount {
@@ -68,12 +94,7 @@ func pickAndAlign(deals []*mtypes.DealInfoIncludePath, ssize abi.SectorSize, spe
 		}
 
 		// deal limit
-		if dealLimit != nil && di >= *dealLimit {
-			break
-		}
-
-		// deal size limit
-		if dealSizeLimit != nil && deal.PieceSize > *dealSizeLimit {
+		if spec != nil && spec.MaxPiece > 0 && di >= spec.MaxPiece {
 			break
 		}
 
@@ -100,6 +121,9 @@ func pickAndAlign(deals []*mtypes.DealInfoIncludePath, ssize abi.SectorSize, spe
 		deal.Offset = offset.Padded()
 		res = append(res, deal)
 
+		pickedDeals++
+		pickedSpace += deal.PieceSize
+
 		space -= deal.PieceSize
 		offset += deal.PieceSize.Unpadded()
 		di++
@@ -107,6 +131,16 @@ func pickAndAlign(deals []*mtypes.DealInfoIncludePath, ssize abi.SectorSize, spe
 
 	// no deals picked, we just do nothing here
 	if len(res) == 0 {
+		return nil, nil
+	}
+
+	// not enough deals
+	if spec != nil && spec.MinPiece > 0 && pickedDeals < spec.MinPiece {
+		return nil, nil
+	}
+
+	// not enough space for deals
+	if spec != nil && spec.MinUsedSpace > 0 && uint64(pickedSpace) < spec.MinUsedSpace {
 		return nil, nil
 	}
 

--- a/storageprovider/deal_assign_util.go
+++ b/storageprovider/deal_assign_util.go
@@ -94,7 +94,7 @@ func pickAndAlign(deals []*mtypes.DealInfoIncludePath, ssize abi.SectorSize, spe
 		}
 
 		// deal limit
-		if spec != nil && spec.MaxPiece > 0 && di >= spec.MaxPiece {
+		if spec != nil && spec.MaxPiece > 0 && pickedDeals >= spec.MaxPiece {
 			break
 		}
 

--- a/storageprovider/deal_assign_util_test.go
+++ b/storageprovider/deal_assign_util_test.go
@@ -141,7 +141,7 @@ func TestDealAssignPickAndAlign(t *testing.T) {
 		},
 
 		{
-			name:              "deal limit",
+			name:              "deal count max limit",
 			sectorSize:        SectorSize2K,
 			sizes:             []abi.PaddedPieceSize{128, 128, 128, 512},
 			spec:              &mtypes.GetDealSpec{MaxPiece: 2},
@@ -151,12 +151,72 @@ func TestDealAssignPickAndAlign(t *testing.T) {
 		},
 
 		{
-			name:              "deal size limit",
+			name:              "deal size max limit",
 			sectorSize:        SectorSize2K,
 			sizes:             []abi.PaddedPieceSize{128, 128, 128, 512},
 			spec:              &mtypes.GetDealSpec{MaxPieceSize: 256},
 			expectedDealIDs:   []abi.DealID{isDeal, isDeal, isDeal, nonDeal, nonDeal, nonDeal},
 			expectedPieceSize: []abi.PaddedPieceSize{128, 128, 128, 128, 512, 1024},
+			expectedErr:       nil,
+		},
+
+		{
+			name:              "deal size min limit, all good",
+			sectorSize:        SectorSize2K,
+			sizes:             []abi.PaddedPieceSize{128, 128, 128, 512},
+			spec:              &mtypes.GetDealSpec{MinPieceSize: 128},
+			expectedDealIDs:   []abi.DealID{isDeal, isDeal, isDeal, nonDeal, isDeal, nonDeal},
+			expectedPieceSize: []abi.PaddedPieceSize{128, 128, 128, 128, 512, 1024},
+			expectedErr:       nil,
+		},
+
+		{
+			name:              "deal size min limit 256",
+			sectorSize:        SectorSize2K,
+			sizes:             []abi.PaddedPieceSize{128, 128, 128, 512},
+			spec:              &mtypes.GetDealSpec{MinPieceSize: 256},
+			expectedDealIDs:   []abi.DealID{isDeal, nonDeal, nonDeal},
+			expectedPieceSize: []abi.PaddedPieceSize{512, 512, 1024},
+			expectedErr:       nil,
+		},
+
+		{
+			name:              "deal min limit 4",
+			sectorSize:        SectorSize2K,
+			sizes:             []abi.PaddedPieceSize{128, 128, 128, 512},
+			spec:              &mtypes.GetDealSpec{MinPiece: 4},
+			expectedDealIDs:   []abi.DealID{isDeal, isDeal, isDeal, nonDeal, isDeal, nonDeal},
+			expectedPieceSize: []abi.PaddedPieceSize{128, 128, 128, 128, 512, 1024},
+			expectedErr:       nil,
+		},
+
+		{
+			name:              "deal min limit 5, empty",
+			sectorSize:        SectorSize2K,
+			sizes:             []abi.PaddedPieceSize{128, 128, 128, 512},
+			spec:              &mtypes.GetDealSpec{MinPiece: 5},
+			expectedDealIDs:   []abi.DealID{},
+			expectedPieceSize: []abi.PaddedPieceSize{},
+			expectedErr:       nil,
+		},
+
+		{
+			name:              "space min limit 128",
+			sectorSize:        SectorSize2K,
+			sizes:             []abi.PaddedPieceSize{128, 256},
+			spec:              nil,
+			expectedDealIDs:   []abi.DealID{isDeal, nonDeal, isDeal, nonDeal, nonDeal},
+			expectedPieceSize: []abi.PaddedPieceSize{128, 128, 256, 512, 1024},
+			expectedErr:       nil,
+		},
+
+		{
+			name:              "space min limit 512, empty",
+			sectorSize:        SectorSize2K,
+			sizes:             []abi.PaddedPieceSize{128, 256},
+			spec:              &mtypes.GetDealSpec{MinUsedSpace: 512},
+			expectedDealIDs:   []abi.DealID{},
+			expectedPieceSize: []abi.PaddedPieceSize{},
 			expectedErr:       nil,
 		},
 	}

--- a/utils/test_helper/mock_fullnode.go
+++ b/utils/test_helper/mock_fullnode.go
@@ -338,6 +338,10 @@ func (m MockFullnode) ChainGetPath(ctx context.Context, from types.TipSetKey, to
 	panic("implement me")
 }
 
+func (m MockFullnode) StateGetNetworkParams(ctx context.Context) (*types.NetworkParams, error) {
+	panic("implement me")
+}
+
 func (m MockFullnode) StateMarketParticipants(ctx context.Context, tsk types.TipSetKey) (map[string]types.MarketBalance, error) {
 	panic("implement me")
 }


### PR DESCRIPTION
- 移除 AssignUnPackedDeals 接口中不必要的前置过滤逻辑
- 处理 MinPiece, MinPieceSize, MinUsedSpace 三种新增策略，并搭配相应的测试用例
- 为升级到 `venus@master` 增补 mock method

**本 pr 应该被 [Venus pr #4885](https://github.com/filecoin-project/venus/pull/4885) 所阻塞，并应当在该pr合并后更新模块依赖**