### PR TITLE
fix: Doesn't clear older illegal addresses in deal initialization with interactive mode.

### DIFF
--- a/cmd/market-client/storage.go
+++ b/cmd/market-client/storage.go
@@ -764,6 +764,7 @@ uiLoop:
 				continue
 			}
 
+			maddrs = nil
 			for _, s := range strings.Fields(maddrsStr) {
 				maddr, err := address.NewFromString(strings.TrimSpace(s))
 				if err != nil {


### PR DESCRIPTION
Doesn't clear older illegal addresses in deal initialization with interactive mode.

Fixes filecoin-project/venus#4879