### PR TITLE
fix handle provider canncel state

### DIFF
--- a/cmd/market-client/client_retr.go
+++ b/cmd/market-client/client_retr.go
@@ -172,7 +172,7 @@ func retrieve(ctx context.Context, cctx *cli.Context, fapi clientapi.IMarketClie
 				break readEvents
 			case retrievalmarket.DealStatusRejected:
 				return nil, fmt.Errorf("retrieval Proposal Rejected: %s", evt.Message)
-			case
+			case retrievalmarket.DealStatusCancelled,
 				retrievalmarket.DealStatusDealNotFound,
 				retrievalmarket.DealStatusErrored:
 				return nil, fmt.Errorf("retrieval Error: %s", evt.Message)


### PR DESCRIPTION
1. `market-client retrieval retrieve` can't exit automatically if provider canceled the retrieval.
   if provider canceled the `retrieval`, the client would receive a `StateCancelled` state, but we haven't handle it.
   
2. the `event` in `market-client retrieval` outputs always be an incorrect '**New**'. as following:
```shell
./market-client retrieval retrieve --provider f01192 --maxPrice 1fil bafk2bzacebbko4p5smouvkzcrcfw7rtapm5h6srptevkpdqzgh3ql47pfcbha ./r_data/bafk2bzacebbko4p5smouvkzcrcfw7rtapm5h6srptevkpdqzgh3ql47pfcbha
Recv 0 B, Paid 0 FIL, New (New), 0s
Recv 0 B, Paid 0 FIL, New (WaitForAcceptance), 2ms
Recv 0 B, Paid 0 FIL, New (Accepted), 16ms
Recv 0 B, Paid 0 FIL, New (PaymentChannelCreating), 43ms
Recv 2.864 KiB, Paid 0 FIL, New (PaymentChannelCreating), 1m25.97s
Recv 2.864 KiB, Paid 0 FIL, New (PaymentChannelCreating), 1m25.97s
Recv 2.864 KiB, Paid 0 FIL, New (PaymentChannelCreating), 1m25.971s
Recv 2.864 KiB, Paid 0 FIL, New (PaymentChannelAllocatingLane), 1m25.971s
Recv 2.864 KiB, Paid 0 FIL, New (Ongoing), 1m25.971s
Recv 2.864 KiB, Paid 0 FIL, New (FundsNeededLastPayment), 1m25.971s
Recv 2.864 KiB, Paid 0 FIL, New (SendFundsLastPayment), 1m25.971s
Recv 2.864 KiB, Paid 0.000000000027315129 FIL, New (Finalizing), 1m25.98s
Recv 2.864 KiB, Paid 0.000000000027315129 FIL, New (Cancelling), 1m25.987s
Recv 2.864 KiB, Paid 0.000000000027315129 FIL, New (Cancelled), 1m25.987s
```

fixes https://github.com/filecoin-project/venus/issues/4852