### PR TITLE
fix: detect ChannelNotFound error with correct approach

### DIFF
--- a/models/badger/paych.go
+++ b/models/badger/paych.go
@@ -128,7 +128,7 @@ func (pr *paychRepo) WithPendingAddFunds(ctx context.Context) ([]*types.ChannelI
 }
 
 // findChan finds a single channel using the given filter.
-// If there isn't a channel that matches the filter, returns ErrChannelNotFound
+// If there isn't a channel that matches the filter, returns repo.ErrNotFound
 func (pr *paychRepo) findChan(ctx context.Context, filter func(ci *types.ChannelInfo) bool) (*types.ChannelInfo, error) {
 	cis, err := pr.findChans(ctx, filter, 1)
 	if err != nil {
@@ -136,7 +136,7 @@ func (pr *paychRepo) findChan(ctx context.Context, filter func(ci *types.Channel
 	}
 
 	if len(cis) == 0 {
-		return nil, types.ErrChannelNotFound
+		return nil, repo.ErrNotFound
 	}
 
 	return cis[0], err

--- a/paychmgr/paych.go
+++ b/paychmgr/paych.go
@@ -527,7 +527,7 @@ func (ca *channelAccessor) laneState(ctx context.Context, state paych.State, ch 
 
 	// Apply locally stored vouchers
 	vouchers, err := ca.vouchersForPaych(ctx, ch)
-	if err != nil && err != types.ErrChannelNotFound {
+	if err != nil && !errors.Is(err, repo.ErrNotFound) {
 		return nil, err
 	}
 

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/filecoin-project/venus-market/v2/models/repo"
 	"sync"
 
 	"github.com/ipfs/go-cid"
@@ -333,10 +334,10 @@ func (ca *channelAccessor) currentAvailableFunds(ctx context.Context, channelID 
 // message to be confirmed on chain)
 func (ca *channelAccessor) processTask(ctx context.Context, amt big.Int) *paychFundsRes {
 	// Get the payment channel for the from/to addresses.
-	// Note: It's ok if we get ErrChannelNotFound. It just means we need to
+	// Note: It's ok if we get repo.ErrNotFound. It just means we need to
 	// create a channel.
 	channelInfo, err := ca.channelInfoRepo.OutboundActiveByFromTo(ctx, ca.from, ca.to)
-	if err != nil && err != types.ErrChannelNotFound {
+	if err != nil && !errors.Is(err, repo.ErrNotFound) {
 		return &paychFundsRes{err: err}
 	}
 

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/filecoin-project/venus-market/v2/models/repo"
 	"sync"
+
+	"github.com/filecoin-project/venus-market/v2/models/repo"
 
 	"github.com/ipfs/go-cid"
 	"golang.org/x/sync/errgroup"


### PR DESCRIPTION
### 修复错误:
没有以正确的方式检测 ChannelNotFound错误, 导致数据检索失败的问题.

### 描述:
在`paychanrepo`的mysql实现中, 如代码所示:
https://github.com/filecoin-project/venus-market/blob/4d8533af0138c2d003dade56ced721ae1eac1b23/models/mysql/paych.go#L128-L136
如果channel不存在, 返回的错误是: `repo.ErrNotFound`

但在`PayChManager`中, 却通过判断err是否等于`types.ErrChannelNotFound`来判断channel是否存在, 此错误最终会导致数据检索失败.
https://github.com/filecoin-project/venus-market/blob/4d8533af0138c2d003dade56ced721ae1eac1b23/paychmgr/manager.go#L312-L321

### 修改方案为:
- [x] venus-market中, 不再使用`types.ErrChannelNotFound`, 统一使用`repo.ErrNotFound`
- [x] 对于所有需要判断`err`是否为`repo.ErrNotFound`的地方, 统一使用 `errors.Is(....)`这种方式, 以增加程序的健壮性.