### PR TITLE
refactor: load v8 actors before solo/pool run

### DIFF
--- a/cmd/venus-market/main.go
+++ b/cmd/venus-market/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/filecoin-project/venus-market/v2/blockstore"
@@ -12,7 +12,6 @@ import (
 	builtinactors "github.com/filecoin-project/venus/venus-shared/builtin-actors"
 	"github.com/filecoin-project/venus/venus-shared/types"
 	"github.com/ipfs-force-community/venus-common-utils/apiinfo"
-	"github.com/mitchellh/go-homedir"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/urfave/cli/v2"
@@ -38,6 +37,8 @@ var (
 	InitJournalKey = builder.NextInvoke() //nolint
 	ExtractApiKey  = builder.NextInvoke()
 )
+
+const marketConfigKey = "market-config"
 
 var (
 	RepoFlag = &cli.StringFlag{
@@ -285,42 +286,29 @@ func flagData(cctx *cli.Context, cfg *config.MarketConfig) error {
 	return nil
 }
 
-var loadActorsWithCmdBefore = func(cctx *cli.Context) error {
-	nodeUrl := cctx.String(NodeUrlFlag.Name)
-	nodeToken := cctx.String(NodeTokenFlag.Name)
-	if len(nodeToken) == 0 {
-		nodeToken = cctx.String(AuthTokeFlag.Name)
-	}
-	repoPath, err := homedir.Expand(cctx.String("repo"))
+var beforeCmdRun = func(cctx *cli.Context) error {
+	cfg, err := prepare(cctx)
 	if err != nil {
 		return err
 	}
-	if len(nodeUrl) == 0 {
-		cfgPath := filepath.Join(repoPath, "config.toml")
-		marketCfg := config.DefaultMarketConfig
-		err = config.LoadConfig(cfgPath, marketCfg)
-		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return err
-		}
-		nodeUrl = marketCfg.Node.Url
-		nodeToken = marketCfg.Node.Token
-	}
+	cctx.Context = context.WithValue(cctx.Context, marketConfigKey, cfg)
+	return nil
+	return fetchAndLoadBundles(cctx.Context, cfg)
+}
 
-	apiInfo := apiinfo.NewAPIInfo(nodeUrl, nodeToken)
+func fetchAndLoadBundles(ctx context.Context, cfg *config.MarketConfig) error {
+	apiInfo := apiinfo.NewAPIInfo(cfg.Node.Url, cfg.Node.Token)
 	addr, err := apiInfo.DialArgs("v1")
 	if err != nil {
 		return err
 	}
-	fullNodeAPI, closer, err := v1.NewFullNodeRPC(cctx.Context, addr, apiInfo.AuthHeader())
+	fullNodeAPI, closer, err := v1.NewFullNodeRPC(ctx, addr, apiInfo.AuthHeader())
 	if err != nil {
 		return err
 	}
 	defer closer()
 
-	networkName, err := fullNodeAPI.StateNetworkName(cctx.Context)
+	networkName, err := fullNodeAPI.StateNetworkName(ctx)
 	if err != nil {
 		return err
 	}
@@ -330,14 +318,14 @@ var loadActorsWithCmdBefore = func(cctx *cli.Context) error {
 		return err
 	}
 	builtinactors.SetNetworkBundle(nt)
-	if err := os.Setenv(builtinactors.RepoPath, repoPath); err != nil {
+	if err := os.Setenv(builtinactors.RepoPath, cfg.HomeDir); err != nil {
 		return fmt.Errorf("set env %s failed %v", builtinactors.RepoPath, err)
 	}
 
 	// preload manifest so that we have the correct code CID inventory for cli since that doesn't
 	// go through CI
 	bs := blockstore.NewMemory()
-	if err := builtinactors.FetchAndLoadBundles(cctx.Context, bs, builtinactors.BuiltinActorReleases); err != nil {
+	if err := builtinactors.FetchAndLoadBundles(ctx, bs, builtinactors.BuiltinActorReleases); err != nil {
 		return fmt.Errorf("failed to loading actor manifest: %v", err)
 	}
 

--- a/cmd/venus-market/main.go
+++ b/cmd/venus-market/main.go
@@ -322,7 +322,7 @@ func fetchAndLoadBundles(ctx context.Context, cfg *config.MarketConfig) error {
 		return err
 	}
 	builtinactors.SetNetworkBundle(nt)
-	if err := os.Setenv(builtinactors.RepoPath, cfg.HomeDir); err != nil {
+	if err := os.Setenv(builtinactors.RepoPath, cfg.MustHomePath()); err != nil {
 		return fmt.Errorf("set env %s failed %v", builtinactors.RepoPath, err)
 	}
 

--- a/cmd/venus-market/main.go
+++ b/cmd/venus-market/main.go
@@ -292,7 +292,6 @@ var beforeCmdRun = func(cctx *cli.Context) error {
 		return err
 	}
 	cctx.Context = context.WithValue(cctx.Context, marketConfigKey, cfg)
-	return nil
 	return fetchAndLoadBundles(cctx.Context, cfg)
 }
 

--- a/cmd/venus-market/main.go
+++ b/cmd/venus-market/main.go
@@ -162,6 +162,11 @@ func main() {
 }
 
 func prepare(cctx *cli.Context) (*config.MarketConfig, error) {
+	if !cctx.IsSet(HidenSignerTypeFlag.Name) {
+		if err := cctx.Set(HidenSignerTypeFlag.Name, "wallet"); err != nil {
+			return nil, fmt.Errorf("set %s with wallet failed %v", HidenSignerTypeFlag.Name, err)
+		}
+	}
 	cfg := config.DefaultMarketConfig
 	cfg.HomeDir = cctx.String(RepoFlag.Name)
 	cfgPath, err := cfg.ConfigPath()

--- a/cmd/venus-market/main.go
+++ b/cmd/venus-market/main.go
@@ -38,7 +38,9 @@ var (
 	ExtractApiKey  = builder.NextInvoke()
 )
 
-const marketConfigKey = "market-config"
+type contextKey string
+
+const contextKeyMarketConfig = contextKey("market-config")
 
 var (
 	RepoFlag = &cli.StringFlag{
@@ -296,7 +298,7 @@ var beforeCmdRun = func(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	cctx.Context = context.WithValue(cctx.Context, marketConfigKey, cfg)
+	cctx.Context = context.WithValue(cctx.Context, contextKeyMarketConfig, cfg)
 	return fetchAndLoadBundles(cctx.Context, cfg)
 }
 

--- a/cmd/venus-market/pool-run.go
+++ b/cmd/venus-market/pool-run.go
@@ -57,12 +57,6 @@ var poolRunCmd = &cli.Command{
 func poolDaemon(cctx *cli.Context) error {
 	utils.SetupLogLevels()
 	ctx := cctx.Context
-	if !cctx.IsSet(HidenSignerTypeFlag.Name) {
-		if err := cctx.Set(HidenSignerTypeFlag.Name, "gateway"); err != nil {
-			return fmt.Errorf("set %s with gateway failed %v", HidenSignerTypeFlag.Name, err)
-		}
-	}
-
 	cfg, ok := cctx.Context.Value(marketConfigKey).(*config.MarketConfig)
 	if !ok {
 		return fmt.Errorf("market config not exists")

--- a/cmd/venus-market/pool-run.go
+++ b/cmd/venus-market/pool-run.go
@@ -57,7 +57,7 @@ var poolRunCmd = &cli.Command{
 func poolDaemon(cctx *cli.Context) error {
 	utils.SetupLogLevels()
 	ctx := cctx.Context
-	cfg, ok := cctx.Context.Value(marketConfigKey).(*config.MarketConfig)
+	cfg, ok := cctx.Context.Value(contextKeyMarketConfig).(*config.MarketConfig)
 	if !ok {
 		return fmt.Errorf("market config not exists")
 	}

--- a/cmd/venus-market/pool-run.go
+++ b/cmd/venus-market/pool-run.go
@@ -50,9 +50,7 @@ var poolRunCmd = &cli.Command{
 		MinerListFlag,
 		PaymentAddressFlag,
 	},
-	Before: func(cctx *cli.Context) error {
-		return loadActorsWithCmdBefore(cctx)
-	},
+	Before: beforeCmdRun,
 	Action: poolDaemon,
 }
 
@@ -64,9 +62,10 @@ func poolDaemon(cctx *cli.Context) error {
 			return fmt.Errorf("set %s with gateway failed %v", HidenSignerTypeFlag.Name, err)
 		}
 	}
-	cfg, err := prepare(cctx)
-	if err != nil {
-		return err
+
+	cfg, ok := cctx.Context.Value(marketConfigKey).(*config.MarketConfig)
+	if !ok {
+		return fmt.Errorf("market config not exists")
 	}
 
 	// venus-auth is must in 'pool' mode

--- a/cmd/venus-market/solo-run.go
+++ b/cmd/venus-market/solo-run.go
@@ -53,7 +53,7 @@ var soloRunCmd = &cli.Command{
 func soloDaemon(cctx *cli.Context) error {
 	utils.SetupLogLevels()
 	ctx := cctx.Context
-	cfg, ok := cctx.Context.Value(marketConfigKey).(*config.MarketConfig)
+	cfg, ok := cctx.Context.Value(contextKeyMarketConfig).(*config.MarketConfig)
 	if !ok {
 		return fmt.Errorf("market config not exists")
 	}

--- a/cmd/venus-market/solo-run.go
+++ b/cmd/venus-market/solo-run.go
@@ -53,12 +53,6 @@ var soloRunCmd = &cli.Command{
 func soloDaemon(cctx *cli.Context) error {
 	utils.SetupLogLevels()
 	ctx := cctx.Context
-
-	if !cctx.IsSet(HidenSignerTypeFlag.Name) {
-		if err := cctx.Set(HidenSignerTypeFlag.Name, "wallet"); err != nil {
-			return fmt.Errorf("set %s with wallet failed %v", HidenSignerTypeFlag.Name, err)
-		}
-	}
 	cfg, ok := cctx.Context.Value(marketConfigKey).(*config.MarketConfig)
 	if !ok {
 		return fmt.Errorf("market config not exists")

--- a/cmd/venus-market/solo-run.go
+++ b/cmd/venus-market/solo-run.go
@@ -46,10 +46,8 @@ var soloRunCmd = &cli.Command{
 		MinerListFlag,
 		PaymentAddressFlag,
 	},
-	Before: func(cctx *cli.Context) error {
-		return loadActorsWithCmdBefore(cctx)
-	},
 	Action: soloDaemon,
+	Before: beforeCmdRun,
 }
 
 func soloDaemon(cctx *cli.Context) error {
@@ -61,9 +59,9 @@ func soloDaemon(cctx *cli.Context) error {
 			return fmt.Errorf("set %s with wallet failed %v", HidenSignerTypeFlag.Name, err)
 		}
 	}
-	cfg, err := prepare(cctx)
-	if err != nil {
-		return err
+	cfg, ok := cctx.Context.Value(marketConfigKey).(*config.MarketConfig)
+	if !ok {
+		return fmt.Errorf("market config not exists")
 	}
 
 	resAPI := &impl.MarketNodeImpl{}

--- a/storageprovider/client.go
+++ b/storageprovider/client.go
@@ -279,7 +279,7 @@ func (c *ClientNodeAdapter) DealProviderCollateralBounds(ctx context.Context, si
 
 // TODO: Remove dealID parameter, change publishCid to be cid.Cid (instead of pointer)
 func (c *ClientNodeAdapter) OnDealSectorPreCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, proposal market.DealProposal, publishCid *cid.Cid, cb storagemarket.DealSectorPreCommittedCallback) error {
-	return c.scMgr.OnDealSectorPreCommitted(ctx, provider, market.DealProposal(proposal), *publishCid, cb)
+	return c.scMgr.OnDealSectorPreCommitted(ctx, provider, proposal, *publishCid, cb)
 }
 
 // TODO: Remove dealID parameter, change publishCid to be cid.Cid (instead of pointer)

--- a/storageprovider/client.go
+++ b/storageprovider/client.go
@@ -284,7 +284,7 @@ func (c *ClientNodeAdapter) OnDealSectorPreCommitted(ctx context.Context, provid
 
 // TODO: Remove dealID parameter, change publishCid to be cid.Cid (instead of pointer)
 func (c *ClientNodeAdapter) OnDealSectorCommitted(ctx context.Context, provider address.Address, dealID abi.DealID, sectorNumber abi.SectorNumber, proposal market.DealProposal, publishCid *cid.Cid, cb storagemarket.DealSectorCommittedCallback) error {
-	return c.scMgr.OnDealSectorCommitted(ctx, provider, sectorNumber, market.DealProposal(proposal), *publishCid, cb)
+	return c.scMgr.OnDealSectorCommitted(ctx, provider, sectorNumber, proposal, *publishCid, cb)
 }
 
 // TODO: Replace dealID parameter with DealProposal

--- a/storageprovider/currentdealinfo.go
+++ b/storageprovider/currentdealinfo.go
@@ -133,7 +133,7 @@ func (mgr *CurrentDealInfoManager) dealIDFromPublishDealsMsg(ctx context.Context
 	// index of the target deal proposal
 	dealIdx := -1
 	for i, paramDeal := range pubDealsParams.Deals {
-		eq, err := mgr.CheckDealEquality(ctx, tok, *proposal, market.DealProposal(paramDeal.Proposal))
+		eq, err := mgr.CheckDealEquality(ctx, tok, *proposal, paramDeal.Proposal)
 		if err != nil {
 			return dealID, types.TipSetKey{}, fmt.Errorf("comparing publish deal message %s proposal to deal proposal: %w", publishCid, err)
 		}

--- a/storageprovider/provider.go
+++ b/storageprovider/provider.go
@@ -279,7 +279,7 @@ func (n *ProviderNodeAdapter) WaitForPublishDeals(ctx context.Context, publishCi
 		return nil, fmt.Errorf("WaitForPublishDeals failed to get chain head: %w", err)
 	}
 
-	res, err := n.dealInfo.GetCurrentDealInfo(ctx, head.Key(), (*market.DealProposal)(&proposal), publishCid)
+	res, err := n.dealInfo.GetCurrentDealInfo(ctx, head.Key(), &proposal, publishCid)
 	if err != nil {
 		return nil, fmt.Errorf("WaitForPublishDeals getting deal info errored: %w", err)
 	}


### PR DESCRIPTION
loadActorsWithCmdBefore函数中, 会解析`MarketConfig`, **同时**在`pool/solo run`中也会解析`MarketConfig`
为了提高代码重用度和可维护性, 采用下面的方式进行重构:
- [x] 合并解析`MarketConfig`的代码
- [x] 在before函数中, 解析完成之后, 放到`cli.Context`中, 在`action`函数中, 通过`context.Value`方式来获取.