### PR TITLE
feat: top level index local persistence

### DIFF
--- a/dagstore/wrapper.go
+++ b/dagstore/wrapper.go
@@ -109,6 +109,8 @@ func NewDAGStore(ctx context.Context, cfg *config.DAGStoreConfig, marketApi Mark
 		if err != nil {
 			return nil, nil, err
 		}
+	} else {
+		dcfg.TopLevelIndex = index.NewInverted(dstore)
 	}
 
 	dagst, err := dagstore.NewDAGStore(dcfg)


### PR DESCRIPTION
save top level indics in to local datastore as default instead of in memory.