### PR TITLE
fix: TestPaychGetRestartAfterAddFundsMsg may stuck in forever waiting

### DIFF
--- a/paychmgr/manager.go
+++ b/paychmgr/manager.go
@@ -108,12 +108,16 @@ func NewManager(mctx metrics.MetricsCtx, repo repo.Repo, msgClient clients.IMixM
 
 // newManager is used by the tests to supply mocks
 func newManager(ctx context.Context, r repo.Repo, pchapi managerAPI) (*Manager, error) {
+	var shutdown context.CancelFunc
+	ctx, shutdown = context.WithCancel(ctx)
 	pm := &Manager{
 		sa:              &stateAccessor{sm: pchapi},
 		channelInfoRepo: r.PaychChannelInfoRepo(),
 		msgInfoRepo:     r.PaychMsgInfoRepo(),
 		channels:        make(map[string]*channelAccessor),
 		pchapi:          pchapi,
+		ctx:             ctx,
+		shutdown:        shutdown,
 	}
 	return pm, pm.Start(ctx)
 }

--- a/paychmgr/paychget_test.go
+++ b/paychmgr/paychget_test.go
@@ -457,14 +457,14 @@ func TestPaychGetRestartAfterAddFundsMsg(t *testing.T) {
 	require.NoError(t, err)
 
 	// Simulate shutting down system
-	mock.close()
+	mgr.Stop()
 
 	// Create a new manager with the same datastore
 	mock2 := newMockManagerAPI()
-	defer mock2.close()
 
 	mgr2, err := newManager(ctx, repo, mock2)
 	require.NoError(t, err)
+	defer mgr2.Stop()
 
 	// Send success add funds response
 	mock2.receiveMsgResponse(mcid2, types.MessageReceipt{

--- a/paychmgr/paychget_test.go
+++ b/paychmgr/paychget_test.go
@@ -458,9 +458,11 @@ func TestPaychGetRestartAfterAddFundsMsg(t *testing.T) {
 
 	// Simulate shutting down system
 	mgr.Stop()
+	mock.close()
 
 	// Create a new manager with the same datastore
 	mock2 := newMockManagerAPI()
+	defer mock2.close()
 
 	mgr2, err := newManager(ctx, repo, mock2)
 	require.NoError(t, err)

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -256,6 +256,11 @@ func (ca *channelAccessor) queueSize() int {
 // msgWaitComplete is called when the message for a previous task is confirmed
 // or there is an error.
 func (ca *channelAccessor) msgWaitComplete(ctx context.Context, mcid cid.Cid, err error) {
+	// this error is caused by shutting down of manager, should not change anything.
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+
 	ca.lk.Lock()
 	defer ca.lk.Unlock()
 
@@ -413,7 +418,7 @@ func (ca *channelAccessor) waitForPaychCreateMsg(ctx context.Context, channelID 
 func (ca *channelAccessor) waitPaychCreateMsg(ctx context.Context, channelID string, mcid cid.Cid) error {
 	mwait, err := ca.api.WaitMsg(ca.chctx, mcid, 1)
 	if err != nil {
-		log.Errorf("wait msg: %w", err)
+		log.Errorf("wait msg: %s", err)
 		return err
 	}
 	// If channel creation failed

--- a/paychmgr/simple.go
+++ b/paychmgr/simple.go
@@ -256,8 +256,8 @@ func (ca *channelAccessor) queueSize() int {
 // msgWaitComplete is called when the message for a previous task is confirmed
 // or there is an error.
 func (ca *channelAccessor) msgWaitComplete(ctx context.Context, mcid cid.Cid, err error) {
-	// this error is caused by shutting down of manager, should not change anything.
-	if errors.Is(err, context.Canceled) {
+	// context related errors should be ignore
+	if err != nil && (errors.Is(err, ca.chctx.Err()) || errors.Is(err, ctx.Err())) {
 		return
 	}
 


### PR DESCRIPTION
**TestPaychGetRestartAfterAddFundsMsg测试中, 可能会陷入永远等待一个不会被触发的channel接收中, 最终导致检查`timeout`失败.**

### 原因分析:
1. 代码`GetPaych`, 会触发非常多的异步代码:
https://github.com/filecoin-project/venus-market/blob/25483cb968588248e12867f934ea1db27f66ea81/paychmgr/paychget_test.go#L454-L457
2. 但最终, 会触发`AddFunds`,并通过`response`管道, 等待消息在链上的`receipt`:
https://github.com/filecoin-project/venus-market/blob/25483cb968588248e12867f934ea1db27f66ea81/paychmgr/mock_test.go#L154-L158

3. 当我们通过`mockapi.close`, 来关闭时, 
https://github.com/filecoin-project/venus-market/blob/25483cb968588248e12867f934ea1db27f66ea81/paychmgr/mock_test.go#L181-L193
第2步中的, 管道会收到正确的`receipt`.

4. 在`channelAccessor.waitAddFundsMsg`中, 会认为消息执行并上链. 最终将`channel.AddFundsMsg`设置为nil, 并更新到repo中.
https://github.com/filecoin-project/venus-market/blob/25483cb968588248e12867f934ea1db27f66ea81/paychmgr/simple.go#L413-L456

5. 然后在启动第二个`manager.Start`-> `manager.restartPending()` -> `pm.channelInfoRepo.WithPendingAddFunds` 拿到空的`channelinfo`数组.(**因为再上面的流程中, 其实`addfunds`消息已经被完成了**)

https://github.com/filecoin-project/venus-market/blob/25483cb968588248e12867f934ea1db27f66ea81/paychmgr/paychget_test.go#L466-L473
最终:`mock2.receiveMsgResponse`会陷入了永远的死等待.

### 重现步骤
在TestPaychGetRestartAfterAddFundsMsg中, 添加`for`循环, 大概率可以重现这个问题:
```go
func TestPaychGetRestartAfterAddFundsMsg(......) {
.........
	defer mock2.close()
	for i := 0; i < 10; i++ {
		fmt.Printf("sleep 100ms\n")
		time.Sleep(time.Millisecond * 100)
	}
	mgr2, err := newManager(ctx, repo, mock2)
.......
```



