### PR TITLE
fix : retrieval market: retrieval provider begins data transfer  in incorrect state.

### DIFF
--- a/retrievalprovider/datatransfer_handler.go
+++ b/retrievalprovider/datatransfer_handler.go
@@ -3,6 +3,7 @@ package retrievalprovider
 import (
 	"context"
 	"fmt"
+
 	datatransfer "github.com/filecoin-project/go-data-transfer"
 	rm "github.com/filecoin-project/go-fil-markets/retrievalmarket"
 	"github.com/filecoin-project/venus-market/v2/models/repo"

--- a/retrievalprovider/datatransfer_handler.go
+++ b/retrievalprovider/datatransfer_handler.go
@@ -43,7 +43,7 @@ func (d *DataTransferHandler) HandleAcceptFor(ctx context.Context, identifier rm
 	if err != nil {
 		return err
 	}
-	// state transfer should follow `ProviderEventDealAccepted` event
+	// state transition should follow `ProviderEventDealAccepted` event
 	// https://github.com/filecoin-project/go-fil-markets/blob/9e5f2499cba68968ffc75a22b89a085c5722f1a5/retrievalmarket/impl/providerstates/provider_fsm.go#L32-L38
 	deal.ChannelID = &channelId
 	if err = d.retrievalDealStore.SaveDeal(ctx, deal); err != nil {


### PR DESCRIPTION
fix: 当检索订单状态为`rm.DealStatusFundsNeededUnseal`时, 
接收到`rm.ProviderEventDealAccepted`事件后, 就直接`UnsealData` 直接开始数据传输, 
最终导致检索服务和客户端的状态混乱订单失败的问题.

fixes: https://github.com/filecoin-project/venus/issues/4908