### PR TITLE
支持按照生命周期过滤分配订单

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/filecoin-project/specs-actors/v7 v7.0.1
 	github.com/filecoin-project/specs-actors/v8 v8.0.1
 	github.com/filecoin-project/specs-storage v0.4.1
-	github.com/filecoin-project/venus v1.6.1-0.20220705010019-246520384fea
+	github.com/filecoin-project/venus v1.6.1-0.20220707073004-2febbe50573a
 	github.com/filecoin-project/venus-auth v1.6.0
 	github.com/filecoin-project/venus-messager v1.6.0
 	github.com/gbrlsnchs/jwt/v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/filecoin-project/specs-actors/v7 v7.0.1
 	github.com/filecoin-project/specs-actors/v8 v8.0.1
 	github.com/filecoin-project/specs-storage v0.4.1
-	github.com/filecoin-project/venus v1.6.1-0.20220707073004-2febbe50573a
+	github.com/filecoin-project/venus v1.6.1-0.20220707095905-e14afe441234
 	github.com/filecoin-project/venus-auth v1.6.0
 	github.com/filecoin-project/venus-messager v1.6.0
 	github.com/gbrlsnchs/jwt/v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -419,10 +419,8 @@ github.com/filecoin-project/storetheindex v0.3.5 h1:KoS9TvjPm6zIZfUH8atAHJbVHOO7
 github.com/filecoin-project/storetheindex v0.3.5/go.mod h1:0r3d0kSpK63O6AvLr1CjAINLi+nWD49clzcnKV+GLpI=
 github.com/filecoin-project/test-vectors/schema v0.0.5/go.mod h1:iQ9QXLpYWL3m7warwvK1JC/pTri8mnfEmKygNDqqY6E=
 github.com/filecoin-project/venus v1.6.0/go.mod h1:ukA+xwqDs40lixoa+HDNfuN8b1G4jpm4k0ujceVejSk=
-github.com/filecoin-project/venus v1.6.1-0.20220705010019-246520384fea h1:tuYNZflPWFFBAHK6pess5F0UOLfeal9zCfImpGKjCYk=
-github.com/filecoin-project/venus v1.6.1-0.20220705010019-246520384fea/go.mod h1:ukA+xwqDs40lixoa+HDNfuN8b1G4jpm4k0ujceVejSk=
-github.com/filecoin-project/venus v1.6.1-0.20220707073004-2febbe50573a h1:SaTQ3iel+OxIZ9c38vAI+j5sxvzsqBm1FWzDexhbq04=
-github.com/filecoin-project/venus v1.6.1-0.20220707073004-2febbe50573a/go.mod h1:ukA+xwqDs40lixoa+HDNfuN8b1G4jpm4k0ujceVejSk=
+github.com/filecoin-project/venus v1.6.1-0.20220707095905-e14afe441234 h1:gsy9AlBtgYALUgMA5Kj2+PEJk2BJ4D/9+NkpG9vFQpA=
+github.com/filecoin-project/venus v1.6.1-0.20220707095905-e14afe441234/go.mod h1:ukA+xwqDs40lixoa+HDNfuN8b1G4jpm4k0ujceVejSk=
 github.com/filecoin-project/venus-auth v1.6.0 h1:DLl7q5g1eh6UTpp98MLpRWAI79k6TUw1Myh/RLeaFpU=
 github.com/filecoin-project/venus-auth v1.6.0/go.mod h1:x/Cv3zz9z5O+/uqIKgYtk5UsL7nYu+CtiPjyVQ8Lywg=
 github.com/filecoin-project/venus-messager v1.6.0 h1:7R0bHYTXSaTy7220cdSBwXDDgFqwzhFTgl06tNQsAmo=

--- a/go.sum
+++ b/go.sum
@@ -421,6 +421,8 @@ github.com/filecoin-project/test-vectors/schema v0.0.5/go.mod h1:iQ9QXLpYWL3m7wa
 github.com/filecoin-project/venus v1.6.0/go.mod h1:ukA+xwqDs40lixoa+HDNfuN8b1G4jpm4k0ujceVejSk=
 github.com/filecoin-project/venus v1.6.1-0.20220705010019-246520384fea h1:tuYNZflPWFFBAHK6pess5F0UOLfeal9zCfImpGKjCYk=
 github.com/filecoin-project/venus v1.6.1-0.20220705010019-246520384fea/go.mod h1:ukA+xwqDs40lixoa+HDNfuN8b1G4jpm4k0ujceVejSk=
+github.com/filecoin-project/venus v1.6.1-0.20220707073004-2febbe50573a h1:SaTQ3iel+OxIZ9c38vAI+j5sxvzsqBm1FWzDexhbq04=
+github.com/filecoin-project/venus v1.6.1-0.20220707073004-2febbe50573a/go.mod h1:ukA+xwqDs40lixoa+HDNfuN8b1G4jpm4k0ujceVejSk=
 github.com/filecoin-project/venus-auth v1.6.0 h1:DLl7q5g1eh6UTpp98MLpRWAI79k6TUw1Myh/RLeaFpU=
 github.com/filecoin-project/venus-auth v1.6.0/go.mod h1:x/Cv3zz9z5O+/uqIKgYtk5UsL7nYu+CtiPjyVQ8Lywg=
 github.com/filecoin-project/venus-messager v1.6.0 h1:7R0bHYTXSaTy7220cdSBwXDDgFqwzhFTgl06tNQsAmo=


### PR DESCRIPTION
是 filecoin-project/venus#4958 的子任务，且应当先完成  filecoin-project/venus#5043