### PR TITLE
refactor: 解耦 payChInfoRepo 和 payMsgRepo

### DIFF
--- a/models/badger/testing.go
+++ b/models/badger/testing.go
@@ -9,18 +9,25 @@ import (
 )
 
 func setup(t *testing.T) repo.Repo {
+	repo, err := NewMemRepo()
+	assert.Nil(t, err)
+	return repo
+}
+
+func NewMemRepo() (repo.Repo, error) {
 	opts := &badger.DefaultOptions
 	opts.InMemory = true
 	db, err := badger.NewDatastore("", opts)
-	assert.Nil(t, err)
-
+	if err != nil {
+		return nil, err
+	}
 	return NewBadgerRepo(BadgerDSParams{
 		FundDS:           NewFundMgrDS(db),
-		StorageDealsDS:   NewStorageDealsDS(db),
+		StorageDealsDS:   NewStorageDealsDS(NewStorageProviderDS(db)),
 		PaychDS:          NewPayChanDS(db),
-		AskDS:            NewStorageAskDS(db),
-		RetrAskDs:        NewRetrievalAskDS(db),
-		CidInfoDs:        NewCidInfoDs(db),
-		RetrievalDealsDs: NewRetrievalDealsDS(db),
-	})
+		AskDS:            NewStorageAskDS(NewStorageProviderDS(db)),
+		RetrAskDs:        NewRetrievalAskDS(NewRetrievalProviderDS(db)),
+		CidInfoDs:        NewCidInfoDs(NewPieceMetaDs(db)),
+		RetrievalDealsDs: NewRetrievalDealsDS(NewRetrievalProviderDS(db)),
+	}), nil
 }

--- a/models/testhelpers.go
+++ b/models/testhelpers.go
@@ -3,19 +3,10 @@ package models
 import (
 	"github.com/filecoin-project/venus-market/v2/models/badger"
 	"github.com/filecoin-project/venus-market/v2/models/repo"
-	ds2 "github.com/ipfs/go-datastore"
 )
 
 // NewInMemoryRepo makes a new instance of MemRepo
 func NewInMemoryRepo() repo.Repo {
-	ds := ds2.NewMapDatastore()
-	return badger.NewBadgerRepo(badger.BadgerDSParams{
-		FundDS:           badger.NewFundMgrDS(ds),
-		StorageDealsDS:   badger.NewStorageDealsDS(ds),
-		PaychDS:          badger.NewPayChanDS(ds),
-		AskDS:            badger.NewStorageAskDS(ds),
-		RetrAskDs:        badger.NewRetrievalAskDS(ds),
-		CidInfoDs:        badger.NewCidInfoDs(ds),
-		RetrievalDealsDs: badger.NewRetrievalDealsDS(ds),
-	})
+	repo, _ := badger.NewMemRepo()
+	return repo
 }


### PR DESCRIPTION

<!-- 改动清单 -->
<!-- provide a clear list of the changes being made-->
### 概述
当前`repo.PaychChannelInfoRepo`和`repo.PaychMsgInfoRepo`两个接口都由`paychRepo`实现, 他们底层的badger ds共享相同的`namespace`: 'paych'.
然后根据具体的业务, 在业务中动态添加上子的`namespace`.

### 改动
此提交将`paychRepo`拆分成两个独立的`namespace`封装的独立类型.
目的是支持: 
[bader数据在不同版本之间的自动迁移的框架的实现](https://github.com/filecoin-project/venus/issues/5283)

### 问题描述


当前的问题是, 在自动迁移时, 由于在底层没有把'namesapce'区分, 迁移框架只能从`paych`的`namespace`开始遍历, 导致在迁移时数据处于混乱状态.
在迁移完成后, 迁移框架会自动在`namespace`中间添加版本号.
例如: 
`/paych/ChannelInfo` -> `paych/1/ChannelInfo`
如果在迁移时自己加上子namespace, 就会变成:
`/paych/ChannelInfo` -> `paych/ChannelInfo/1/`, 但是在具体的业务中, 又指定了`ChannelInfo/xxxx`, 
所以, 在迁移之前动态添加子空间是行不通的.

如果进行拆分, 以`repo.PaychChannelInfoRepo`为例:
其默认的namespace就是`/paych/ChannelInfo`, 完成后, 变成`/paych/ChannelInfo/1/...`,

而业务中, 也不会在查询时同态的添加`namespace`, 所以, 不会有任何问题.

## 自查清单 (Checklist)

在你认为本 PR 满足被审阅的标准之前，需要确保 / Before you mark the PR ready for review, please make sure that:
- [ ] 符合Venus项目管理规范中关于PR的[相关标准](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E9%A1%B9%E7%9B%AE%E7%AE%A1%E7%90%86/Venus/PR%E5%91%BD%E5%90%8D%E8%A7%84%E8%8C%83.md) / The PR follows the PR standards set out in the Venus project management guidelines
- [ ] 具有清晰明确的[commit message](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/git%E4%BD%BF%E7%94%A8/commit-message%E9%A3%8E%E6%A0%BC%E8%A7%84%E8%8C%83.md) / All commits have a clear commit message.
- [ ] 包含相关的的[测试用例](https://github.com/ipfs-force-community/dev-guidances/blob/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E4%BB%A3%E7%A0%81/%E4%BB%A3%E7%A0%81%E5%BA%93/%E6%A3%80%E6%9F%A5%E9%A1%B9/%E5%8D%95%E5%85%83%E6%B5%8B%E8%AF%95.md)或者不需要新增测试用例 / This PR has tests for new functionality or change in behaviour or not need to add new tests.
- [ ] 包含相关的的指南以及[文档](https://github.com/ipfs-force-community/dev-guidances/tree/master/%E8%B4%A8%E9%87%8F%E7%AE%A1%E7%90%86/%E6%96%87%E6%A1%A3)或者不需要新增文档 / This PR has updated usage guidelines and documentation or not need 
- [ ] 通过必要的检查项 / All checks are green
